### PR TITLE
Add asset file count to hardware API

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -163,6 +163,7 @@ class AssetsController extends Controller
 //                    ->orderBy('created_at')
 //                    ->limit(1),
 //            ])
+            ->withCount('uploads as asset_file_count')
             ->with(
                 'model',
                 'location',

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -154,6 +154,23 @@ class AssetsController extends Controller
         }
 
         $assets = Asset::select('assets.*')
+            ->selectSub(
+                Actionlog::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('action_logs.item_id', 'assets.id')
+                    ->where('action_logs.item_type', Asset::class)
+                    ->where('action_logs.action_type', 'uploaded')
+                    ->whereNotNull('action_logs.filename')
+                    ->whereNotExists(function ($query) {
+                        $query->selectRaw('1')
+                            ->from('action_logs as deleted_uploads')
+                            ->whereColumn('deleted_uploads.item_id', 'action_logs.item_id')
+                            ->whereColumn('deleted_uploads.filename', 'action_logs.filename')
+                            ->where('deleted_uploads.item_type', Asset::class)
+                            ->where('deleted_uploads.action_type', 'upload deleted');
+                    }),
+                'asset_file_count'
+            )
 //            ->addSelect([
 //                'first_checkout_at' => Actionlog::query()
 //                    ->select('created_at')
@@ -163,7 +180,6 @@ class AssetsController extends Controller
 //                    ->orderBy('created_at')
 //                    ->limit(1),
 //            ])
-            ->withCount('uploads as asset_file_count')
             ->with(
                 'model',
                 'location',

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -113,6 +113,7 @@ class AssetsTransformer
             'checkin_counter' => (int) $asset->checkin_counter,
             'checkout_counter' => (int) $asset->checkout_counter,
             'requests_counter' => (int) $asset->requests_counter,
+            'asset_file_count' => (int) ($asset->asset_file_count ?? $asset->uploads()->count()),
             'user_can_checkout' => (bool) $asset->availableForCheckout(),
             'book_value' => Helper::formatCurrencyOutput($asset->getDepreciatedValue()),
         ];

--- a/tests/Feature/Assets/Api/AssetIndexTest.php
+++ b/tests/Feature/Assets/Api/AssetIndexTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Assets\Api;
 
+use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\Company;
 use App\Models\User;
@@ -199,5 +200,46 @@ class AssetIndexTest extends TestCase
                 'rows',
             ])
             ->assertJson(fn(AssertableJson $json) => $json->has('rows', 3)->etc());
+    }
+
+    public function testAssetApiIndexReturnsAssetFileCount()
+    {
+        $assetWithFiles = Asset::factory()->create();
+        $assetWithoutFiles = Asset::factory()->create();
+
+        Actionlog::factory()->create([
+            'item_id' => $assetWithFiles->id,
+            'item_type' => Asset::class,
+            'action_type' => 'uploaded',
+            'filename' => 'asset-file-a.txt',
+        ]);
+
+        Actionlog::factory()->create([
+            'item_id' => $assetWithFiles->id,
+            'item_type' => Asset::class,
+            'action_type' => 'uploaded',
+            'filename' => 'asset-file-b.txt',
+        ]);
+
+        Actionlog::factory()->create([
+            'item_id' => $assetWithFiles->id,
+            'item_type' => Asset::class,
+            'action_type' => 'upload deleted',
+            'filename' => 'asset-file-b.txt',
+        ]);
+
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.assets.index', [
+                'sort' => 'id',
+                'order' => 'asc',
+                'offset' => '0',
+                'limit' => '20',
+            ]))
+            ->assertOk();
+
+        $rows = collect($response->json('rows'))->keyBy('id');
+
+        $this->assertSame(1, $rows[$assetWithFiles->id]['asset_file_count']);
+        $this->assertSame(0, $rows[$assetWithoutFiles->id]['asset_file_count']);
     }
 }


### PR DESCRIPTION
## Summary
- include asset_file_count in the hardware index API response
- count uploaded files per asset while excluding deleted uploads
- add a focused API test for the new field

## Testing
- php -l app/Http/Controllers/Api/AssetsController.php
- php -l app/Http/Transformers/AssetsTransformer.php
- php -l tests/Feature/Assets/Api/AssetIndexTest.php
- php artisan test tests/Feature/Assets/Api/AssetIndexTest.php *(blocked locally because vendor/autoload.php is missing in this checkout)*