### PR TITLE
Fix API uploaded file path joins

### DIFF
--- a/app/Http/Controllers/Api/UploadedFilesController.php
+++ b/app/Http/Controllers/Api/UploadedFilesController.php
@@ -18,6 +18,17 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class UploadedFilesController extends Controller
 {
+    protected static function joinStoragePath(string $directory, string $filename = ''): string
+    {
+        $directory = trim($directory, '/');
+        $filename = ltrim($filename, '/');
+
+        if ($filename === '') {
+            return $directory;
+        }
+
+        return $directory.'/'.$filename;
+    }
 
 
     /**
@@ -159,7 +170,7 @@ class UploadedFilesController extends Controller
         }
 
 
-        if (! Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename)) {
+        if (! Storage::exists(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename))) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.file_upload_status.file_not_found'), 200));
         }
 
@@ -167,10 +178,10 @@ class UploadedFilesController extends Controller
             $headers = [
                 'Content-Disposition' => 'inline',
             ];
-            return Storage::download(self::$map_storage_path[$object_type].'/'.$log->filename, $log->filename, $headers);
+            return Storage::download(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename), $log->filename, $headers);
         }
 
-        return StorageHelper::downloader(self::$map_storage_path[$object_type].'/'.$log->filename);
+        return StorageHelper::downloader(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename));
 
     }
 
@@ -206,8 +217,8 @@ class UploadedFilesController extends Controller
 
         if ($log) {
             // Check the file actually exists, and delete it
-            if (Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename)) {
-                Storage::delete(self::$map_storage_path[$object_type].'/'.$log->filename);
+            if (Storage::exists(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename))) {
+                Storage::delete(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename));
             }
             // Delete the record of the file
             if ($log->logUploadDelete($object, $log->filename)) {


### PR DESCRIPTION
## Summary
- keep the original UI upload behavior unchanged
- normalize uploaded file path joins only in the API controller
- avoid `//` in API read/download/delete paths while preserving existing object storage keys

## Context
Commit `f821311` fixed double slashes by removing trailing slashes from `map_storage_path`, but that also changed where uploaded files were written in object storage. The original app UI behavior worked before, so this PR limits the fix to the API controller only.

## Testing
- `php -l app/Http/Controllers/Api/UploadedFilesController.php`
- `php -l app/Http/Controllers/UploadedFilesController.php`
- `php -l app/Http/Controllers/Controller.php`

Full Laravel tests were not run in this workspace because `vendor/` is missing.