### PR TITLE
Fix private upload paths on intern v8.4.0

### DIFF
--- a/app/Http/Controllers/Api/UploadedFilesController.php
+++ b/app/Http/Controllers/Api/UploadedFilesController.php
@@ -18,7 +18,17 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class UploadedFilesController extends Controller
 {
+    protected static function joinStoragePath(string $directory, string $filename = ''): string
+    {
+        $directory = trim($directory, '/');
+        $filename = ltrim($filename, '/');
 
+        if ($filename === '') {
+            return $directory;
+        }
+
+        return $directory.'/'.$filename;
+    }
 
     /**
      * List files for an object
@@ -159,7 +169,7 @@ class UploadedFilesController extends Controller
         }
 
 
-        if (! Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename)) {
+        if (! Storage::exists(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename))) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.file_upload_status.file_not_found'), 200));
         }
 
@@ -167,10 +177,10 @@ class UploadedFilesController extends Controller
             $headers = [
                 'Content-Disposition' => 'inline',
             ];
-            return Storage::download(self::$map_storage_path[$object_type].'/'.$log->filename, $log->filename, $headers);
+            return Storage::download(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename), $log->filename, $headers);
         }
 
-        return StorageHelper::downloader(self::$map_storage_path[$object_type].'/'.$log->filename);
+        return StorageHelper::downloader(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename));
 
     }
 
@@ -206,8 +216,8 @@ class UploadedFilesController extends Controller
 
         if ($log) {
             // Check the file actually exists, and delete it
-            if (Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename)) {
-                Storage::delete(self::$map_storage_path[$object_type].'/'.$log->filename);
+            if (Storage::exists(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename))) {
+                Storage::delete(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename));
             }
             // Delete the record of the file
             if ($log->logUploadDelete($object, $log->filename)) {

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -58,18 +58,18 @@ abstract class Controller extends BaseController
     ];
 
     static $map_storage_path = [
-        'accessories' => 'private_uploads/accessories',
-        'maintenances' => 'private_uploads/maintenances',
-        'assets' => 'private_uploads/assets',
-        'audits' => 'private_uploads/audits',
-        'components' => 'private_uploads/components',
-        'consumables' => 'private_uploads/consumables',
-        'hardware' => 'private_uploads/assets',
-        'licenses' => 'private_uploads/licenses',
-        'locations' => 'private_uploads/locations',
-        'models' => 'private_uploads/models',
-        'suppliers' => 'private_uploads/suppliers',
-        'users' => 'private_uploads/users',
+        'accessories' => 'private_uploads/accessories/',
+        'maintenances' => 'private_uploads/maintenances/',
+        'assets' => 'private_uploads/assets/',
+        'audits' => 'private_uploads/audits/',
+        'components' => 'private_uploads/components/',
+        'consumables' => 'private_uploads/consumables/',
+        'hardware' => 'private_uploads/assets/',
+        'licenses' => 'private_uploads/licenses/',
+        'locations' => 'private_uploads/locations/',
+        'models' => 'private_uploads/models/',
+        'suppliers' => 'private_uploads/suppliers/',
+        'users' => 'private_uploads/users/',
     ];
 
     static $map_file_prefix= [


### PR DESCRIPTION
## Summary
- restore trailing slashes in `map_storage_path` so uploads are written back into the correct private subfolders
- keep the API-specific path join normalization for read, download, and delete operations
- avoid changing the original UI controller behavior

## Context
`intern/v8.4.0` currently contains commit `f821311` (`Fix double slash in private upload paths`). That change removed the trailing slashes from `map_storage_path`, which fixed an API path symptom but also changed where uploaded files are written in object storage.

This PR fixes the deployed branch by:
- undoing the write-path regression in `Controller.php`
- keeping the API-side path normalization in `Api/UploadedFilesController.php`

This supersedes PR #7, which only addressed the API read-side symptom.

## Testing
- `php -l app/Http/Controllers/Controller.php`
- `php -l app/Http/Controllers/Api/UploadedFilesController.php`

Full Laravel tests were not run in this workspace because `vendor/` is missing.