### PR TITLE
Fix UI uploaded file path joins on intern v8.4.0

### DIFF
--- a/app/Http/Controllers/UploadedFilesController.php
+++ b/app/Http/Controllers/UploadedFilesController.php
@@ -23,6 +23,17 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class UploadedFilesController extends Controller
 {
+    protected static function joinStoragePath(string $directory, string $filename = ''): string
+    {
+        $directory = trim($directory, '/');
+        $filename = ltrim($filename, '/');
+
+        if ($filename === '') {
+            return $directory;
+        }
+
+        return $directory.'/'.$filename;
+    }
 
 
     /**
@@ -102,7 +113,7 @@ class UploadedFilesController extends Controller
         }
 
 
-        if (! Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename))
+        if (! Storage::exists(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename)))
         {
             return redirect()->back()->withFragment('files')->with('error', trans('general.file_upload_status.file_not_found'));
         }
@@ -111,10 +122,10 @@ class UploadedFilesController extends Controller
             $headers = [
                 'Content-Disposition' => 'inline',
             ];
-            return Storage::download(self::$map_storage_path[$object_type].'/'.$log->filename, $log->filename, $headers);
+            return Storage::download(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename), $log->filename, $headers);
         }
 
-        return StorageHelper::downloader(self::$map_storage_path[$object_type].'/'.$log->filename);
+        return StorageHelper::downloader(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename));
 
     }
 
@@ -146,8 +157,8 @@ class UploadedFilesController extends Controller
 
         if ($log) {
             // Check the file actually exists, and delete it
-            if (Storage::exists(self::$map_storage_path[$object_type].'/'.$log->filename)) {
-                Storage::delete(self::$map_storage_path[$object_type].'/'.$log->filename);
+            if (Storage::exists(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename))) {
+                Storage::delete(self::joinStoragePath(self::$map_storage_path[$object_type], $log->filename));
             }
             // Delete the record of the file
             if ($log->logUploadDelete($object, $log->filename)) {


### PR DESCRIPTION
## Summary
- normalize uploaded file path joins in the UI uploaded files controller
- avoid double slashes in Spaces/S3 private file URLs from the UI
- keep the fix scoped to the remaining UI read/download/delete path handling

## Context
`intern/v8.4.0` already has the upload destination fix merged, but the UI uploaded-files controller still builds paths with:

`self::$map_storage_path[$object_type].'/'.$log->filename`

Because `map_storage_path` now ends with a trailing slash again, that produced private file URLs like:

`private_uploads/assets//asset-...pdf`

The API controller was already normalized. This PR applies the same join normalization to the UI controller.

## Testing
- `php -l app/Http/Controllers/UploadedFilesController.php`

Full Laravel tests were not run in this workspace because `vendor/` is missing.